### PR TITLE
Fix/mobile/add login default prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papinotas/phoenix-mobile-toolbox",
-  "version": "0.0.1-alpha.13",
+  "version": "0.0.1-alpha.14",
   "description": "Components for react-native",
   "main": "./src/index.js",
   "typings": "./typings/index.d.ts",

--- a/src/components/Login/LoginBody.js
+++ b/src/components/Login/LoginBody.js
@@ -1,13 +1,7 @@
-import React from 'react';
-import {
-  View,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableHighlight,
-} from 'react-native';
-import Icon from 'react-native-vector-icons/MaterialIcons';
 import Proptypes from 'prop-types';
+import React from 'react';
+import { StyleSheet, Text, TextInput, TouchableHighlight, View } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 import colors from '../../styles/colors';
 
 /**
@@ -108,6 +102,7 @@ class LoginBody extends React.Component {
 
   render() {
     const {
+      defaultEmail,
       bodyTitle,
       bodySubtitle,
       beforeInputText,
@@ -128,6 +123,7 @@ class LoginBody extends React.Component {
           <Text style={styles.subtitle}>{bodySubtitle}</Text>
           <Text style={styles.beforeInputText}>{beforeInputText}</Text>
           <TextInput
+            defaultValue={defaultEmail}
             style={styles.emailInput}
             placeholder={firstInputPlaceholder}
             onChangeText={text => onChangeEmail(text)}
@@ -181,6 +177,7 @@ class LoginBody extends React.Component {
 export default LoginBody;
 
 LoginBody.propTypes = {
+  defaultEmail: Proptypes.string,
   bodyTitle: Proptypes.string,
   bodySubtitle: Proptypes.string,
   beforeInputText: Proptypes.string,
@@ -191,6 +188,7 @@ LoginBody.propTypes = {
 };
 
 LoginBody.default = {
+  defaultEmail: '',
   bodyTitle: '',
   bodySubtitle: '',
   beforeInputText: '',

--- a/src/components/Login/LoginScreen.js
+++ b/src/components/Login/LoginScreen.js
@@ -1,8 +1,8 @@
 /* @flow */
-import React from 'react';
-import { LoginHeader, LoginBody, LoginButtons } from './';
 import Proptypes from 'prop-types';
+import React from 'react';
 import { KeyboardAvoidingView } from 'react-native';
+import { LoginBody, LoginButtons, LoginHeader } from './';
 
 /**
  *
@@ -28,6 +28,7 @@ import { KeyboardAvoidingView } from 'react-native';
  *     ];
  * 
  *     const props = {
+ *       defaultEmail: '',
  *       source: require('..'),
  *       headerStyle: styles.headerStyle,
  *       bodyTitle: '',
@@ -49,6 +50,7 @@ import { KeyboardAvoidingView } from 'react-native';
 export default class LoginScreen extends React.Component {
   render() {
     const {
+      defaultEmail,
       source,
       headerStyle,
       bodyTitle,
@@ -65,6 +67,7 @@ export default class LoginScreen extends React.Component {
       <KeyboardAvoidingView behavior="position" keyboardVerticalOffset={64}>
         <LoginHeader source={source} headerStyle={headerStyle} />
         <LoginBody
+          defaultEmail={defaultEmail}
           bodyTitle={bodyTitle}
           bodySubtitle={bodySubtitle}
           beforeInputText={beforeInputText}
@@ -80,6 +83,7 @@ export default class LoginScreen extends React.Component {
 }
 
 LoginScreen.propTypes = {
+  defaultEmail: Proptypes.string,
   source: Proptypes.number,
   headerStyle: Proptypes.object,
   bodyTitle: Proptypes.string,
@@ -93,6 +97,7 @@ LoginScreen.propTypes = {
 };
 
 LoginScreen.default = {
+  defaultEmail: '',
   headerStyle: {},
   bodyTitle: '',
   bodySubtitle: '',

--- a/typings/components/Login.d.ts
+++ b/typings/components/Login.d.ts
@@ -7,6 +7,7 @@ export interface LoginHeaderProps{
 }
 
 export interface LoginBodyProps{
+  defaultEmail?: string;
   bodyTitle?: string;
   bodySubtitle?: string;
   beforeInputText?: string;


### PR DESCRIPTION
* Add email default prop to `Login.Body` and `Login.Screen`

https://github.com/Papinotas-Desarrollo/phoenix-mobile-toolbox/releases/edit/untagged-648b9c3b0017d7507219