### PR TITLE
chore: add hexToRgbAWithOpacity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@papinotas/phoenix-mobile-toolbox",
-  "version": "0.0.1-alpha.19",
+  "version": "0.0.1-alpha.20",
   "description": "Components for react-native",
   "main": "./src/index.js",
   "typings": "./typings/index.d.ts",

--- a/typings/utils/hexToRgbAWithOpacity.d.ts
+++ b/typings/utils/hexToRgbAWithOpacity.d.ts
@@ -1,0 +1,8 @@
+
+/**
+ * @param {string} hex string based hex color
+ * @param {number} opacity (Optional) opacity number (0 -> 1)
+ * @description Function returns an rgba(*) string for setting backgroundColor
+ * with opacity for a component.
+ */
+export declare function hexToRgbAWithOpacity(hex: String, opacity?: Number): String;

--- a/typings/utils/index.d.ts
+++ b/typings/utils/index.d.ts
@@ -1,3 +1,5 @@
+import { hexToRgbAWithOpacity } from './hexToRgbAWithOpacity';
 import { sa } from './safeAccess';
 
-export { sa };
+export { sa, hexToRgbAWithOpacity };
+


### PR DESCRIPTION
* Add `hexToRgbAWithOpacity` on intellisense index

https://github.com/Papinotas-Desarrollo/phoenix-mobile-toolbox/releases/edit/untagged-3fa68f5a765a0b272f55